### PR TITLE
fix: nginx unattended upgrades

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,8 @@ RUN curl -skL "https://nginx.org/keys/nginx_signing.key" | gpg --dearmor >"/usr/
 	&& chown -R nobody:nogroup /app
 
 RUN cp /etc/apt/apt.conf.d/50unattended-upgrades /etc/apt/apt.conf.d/52unattended-upgrades-local \
-  && sed -i '/codename=\${distro_codename}-security,label=Debian-Security";/a\\        "origin=nginx,archive=stable,label=nginx";' /etc/apt/apt.conf.d/52unattended-upgrades-local
+  && sed -i '/codename=\${distro_codename}-security,label=Debian-Security";/a\\        "origin=nginx,archive=stable,label=nginx";' /etc/apt/apt.conf.d/52unattended-upgrades-local \
+  && grep -q 'origin=nginx,archive=stable,label=nginx' /etc/apt/apt.conf.d/52unattended-upgrades-local || (echo "ErrorEditingUnattendedUpgradesConfigFile" && exit 1)
 
 RUN curl -skL "https://mise.run" | sh \
 	&& mv /root/.local/bin/mise /usr/bin/mise \

--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,9 @@ RUN apt-get update && apt-get upgrade -y \
 	curl debian-archive-keyring git gnupg2 haveged lsb-release procps rsync supervisor \
 	tar unzip vim wget zip unattended-upgrades
 
+RUN cp /etc/apt/apt.conf.d/50unattended-upgrades /etc/apt/apt.conf.d/52unattended-upgrades-local \
+  && sed -i '/codename=\${distro_codename}-security,label=Debian-Security";/a\\        "origin=nginx,archive=stable,label=nginx";' /etc/apt/apt.conf.d/52unattended-upgrades-local
+
 RUN curl -skL "https://nginx.org/keys/nginx_signing.key" | gpg --dearmor >"/usr/share/keyrings/nginx-archive-keyring.gpg" \
 	&& echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian $(lsb_release -cs) nginx" >"/etc/apt/sources.list.d/nginx.list" \
 	&& install_packages nginx \

--- a/Containerfile
+++ b/Containerfile
@@ -7,15 +7,15 @@ RUN apt-get update && apt-get upgrade -y \
 	curl debian-archive-keyring git gnupg2 haveged lsb-release procps rsync supervisor \
 	tar unzip vim wget zip unattended-upgrades
 
-RUN cp /etc/apt/apt.conf.d/50unattended-upgrades /etc/apt/apt.conf.d/52unattended-upgrades-local \
-  && sed -i '/codename=\${distro_codename}-security,label=Debian-Security";/a\\        "origin=nginx,archive=stable,label=nginx";' /etc/apt/apt.conf.d/52unattended-upgrades-local
-
 RUN curl -skL "https://nginx.org/keys/nginx_signing.key" | gpg --dearmor >"/usr/share/keyrings/nginx-archive-keyring.gpg" \
 	&& echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian $(lsb_release -cs) nginx" >"/etc/apt/sources.list.d/nginx.list" \
 	&& install_packages nginx \
 	&& mkdir -p /app/logs/cron /app/logs/nginx /app/conf/pki /app/.trash \
 	&& mkdir -m 777 -p /app/html \
 	&& chown -R nobody:nogroup /app
+
+RUN cp /etc/apt/apt.conf.d/50unattended-upgrades /etc/apt/apt.conf.d/52unattended-upgrades-local \
+  && sed -i '/codename=\${distro_codename}-security,label=Debian-Security";/a\\        "origin=nginx,archive=stable,label=nginx";' /etc/apt/apt.conf.d/52unattended-upgrades-local
 
 RUN curl -skL "https://mise.run" | sh \
 	&& mv /root/.local/bin/mise /usr/bin/mise \


### PR DESCRIPTION
Closes #319 

## What

Adds a local override for `unattended-upgrades` to allow packages from the nginx.org repository to be upgraded automatically.

## How

Following the approach recommended in the [Debian wiki](https://wiki.debian.org/PeriodicUpdates#Configure_unattended-upgrades), a local override file is used instead of modifying the upstream config directly — this avoids conflicts if `unattended-upgrades` is upgraded and ships a new
`50unattended-upgrades`.

Changes to `Containerfile`:

```dockerfile
RUN cp /etc/apt/apt.conf.d/50unattended-upgrades /etc/apt/apt.conf.d/52unattended-upgrades-local \
    && sed -i '/codename=\${distro_codename}-security,label=Debian-Security";/a\\        "origin=nginx,archive=stable,label=nginx";' /etc/apt/apt.conf.d/52unattended-upgrades-local
```

## Note

- The anchor in `sed` targets the last Debian entry in the `Origins-Pattern` block, making the change resilient to future additions to the upstream file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build to adjust automatic package update behavior.
  * Added a local override to ensure the Nginx stable repository is included for unattended upgrades.
  * Build now verifies the override and fails early with a clear error if the expected repository entry is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->